### PR TITLE
Add relevant keywords

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -16,6 +16,7 @@ export const metadata = {
   metadataBase: new URL("https://chihkaiyin.blog"),
   creator: "ChihKai Yin",
   description: "A blog built by ChihKai Yin.",
+  keywords: ["chihkai yin", "programming", "web development", "nextjs", "typscript", "express", "javascript"],
   openGraph: {
     title: "ChihKai Yin",
     description: "I write things I have learned.",


### PR DESCRIPTION
Including relevant keywords in your metadata can improve the search engine ranking of your website. When people search for terms like "ChihKai Yin," "programming," "web development," "Next.js," "TypeScript," and "Express," your website is more likely to appear in search results; wjhen your domain authority reaches a certain number.

```html
<meta name="keywords" content="ChihKai Yin, programming, web development, Next.js, TypeScript, Express" />
```
Source: [Nextjs Docs](https://nextjs.org/docs/app/api-reference/functions/generate-metadata)